### PR TITLE
feat: implement iTerm2 focus application

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .worktrees
+.build/
+build/
+.swiftpm/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,24 @@
+{
+    "configurations": [
+        {
+            "type": "swift",
+            "request": "launch",
+            "args": [],
+            "cwd": "${workspaceFolder:app-spec}",
+            "name": "Debug itermfocus",
+            "target": "itermfocus",
+            "configuration": "debug",
+            "preLaunchTask": "swift: Build Debug itermfocus"
+        },
+        {
+            "type": "swift",
+            "request": "launch",
+            "args": [],
+            "cwd": "${workspaceFolder:app-spec}",
+            "name": "Release itermfocus",
+            "target": "itermfocus",
+            "configuration": "release",
+            "preLaunchTask": "swift: Build Release itermfocus"
+        }
+    ]
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,23 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "itermfocus",
+    platforms: [
+        .macOS(.v12)
+    ],
+    targets: [
+        .executableTarget(
+            name: "itermfocus",
+            path: "Sources/itermfocus",
+            linkerSettings: [
+                .unsafeFlags([
+                    "-Xlinker", "-sectcreate",
+                    "-Xlinker", "__TEXT",
+                    "-Xlinker", "__info_plist",
+                    "-Xlinker", "Resources/Info.plist"
+                ])
+            ]
+        )
+    ]
+)

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleIdentifier</key>
+    <string>com.mifkata.itermfocus</string>
+    <key>CFBundleName</key>
+    <string>itermfocus</string>
+    <key>CFBundleExecutable</key>
+    <string>itermfocus</string>
+    <key>CFBundleVersion</key>
+    <string>1.0</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>LSBackgroundOnly</key>
+    <true/>
+    <key>CFBundleURLTypes</key>
+    <array>
+        <dict>
+            <key>CFBundleURLName</key>
+            <string>com.mifkata.itermfocus</string>
+            <key>CFBundleURLSchemes</key>
+            <array>
+                <string>itermfocus</string>
+            </array>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/Sources/itermfocus/AppDelegate.swift
+++ b/Sources/itermfocus/AppDelegate.swift
@@ -1,0 +1,31 @@
+import AppKit
+
+class AppDelegate: NSObject, NSApplicationDelegate {
+    func applicationWillFinishLaunching(_ notification: Notification) {
+        NSAppleEventManager.shared().setEventHandler(
+            self,
+            andSelector: #selector(handleGetURL(_:withReplyEvent:)),
+            forEventClass: AEEventClass(kInternetEventClass),
+            andEventID: AEEventID(kAEGetURL)
+        )
+    }
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+            NSApplication.shared.terminate(nil)
+        }
+    }
+
+    @objc func handleGetURL(_ event: NSAppleEventDescriptor, withReplyEvent replyEvent: NSAppleEventDescriptor) {
+        guard let urlString = event.paramDescriptor(forKeyword: keyDirectObject)?.stringValue,
+              let components = URLComponents(string: urlString),
+              let sessionId = components.queryItems?.first(where: { $0.name == "sessionId" })?.value else {
+            FileHandle.standardError.write(Data("Invalid URL or missing sessionId parameter\n".utf8))
+            NSApplication.shared.terminate(nil)
+            return
+        }
+
+        ITerm2Focuser.focus(sessionId: sessionId)
+        NSApplication.shared.terminate(nil)
+    }
+}

--- a/Sources/itermfocus/ITerm2Focuser.swift
+++ b/Sources/itermfocus/ITerm2Focuser.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+enum ITerm2Focuser {
+    static func extractUUID(from sessionId: String) -> String {
+        if sessionId.contains(":") {
+            return String(sessionId.split(separator: ":").last ?? Substring(sessionId))
+        }
+        return sessionId
+    }
+
+    @discardableResult
+    static func focus(sessionId: String) -> Bool {
+        let uuid = extractUUID(from: sessionId)
+
+        let script = """
+        tell application "iTerm2"
+            repeat with w in windows
+                repeat with t in tabs of w
+                    repeat with s in sessions of t
+                        if unique id of s is "\(uuid)" then
+                            select t
+                            select s
+                            set index of w to 1
+                            activate
+                            return "ok"
+                        end if
+                    end repeat
+                end repeat
+            end repeat
+            return "not found"
+        end tell
+        """
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+        process.arguments = ["-e", script]
+
+        let stdout = Pipe()
+        let stderr = Pipe()
+        process.standardOutput = stdout
+        process.standardError = stderr
+
+        do {
+            try process.run()
+            process.waitUntilExit()
+        } catch {
+            FileHandle.standardError.write(Data("Failed to run osascript: \(error)\n".utf8))
+            return false
+        }
+
+        if process.terminationStatus != 0 {
+            let errorData = stderr.fileHandleForReading.readDataToEndOfFile()
+            if let errorMessage = String(data: errorData, encoding: .utf8), !errorMessage.isEmpty {
+                FileHandle.standardError.write(Data("osascript error: \(errorMessage)".utf8))
+            }
+            return false
+        }
+
+        let outputData = stdout.fileHandleForReading.readDataToEndOfFile()
+        let output = String(data: outputData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+        if output == "not found" {
+            FileHandle.standardError.write(Data("Session not found: \(uuid)\n".utf8))
+            return false
+        }
+
+        return true
+    }
+}

--- a/Sources/itermfocus/main.swift
+++ b/Sources/itermfocus/main.swift
@@ -1,0 +1,12 @@
+import AppKit
+
+if CommandLine.arguments.count > 1 {
+    let sessionId = CommandLine.arguments[1]
+    let success = ITerm2Focuser.focus(sessionId: sessionId)
+    exit(success ? 0 : 1)
+} else {
+    let app = NSApplication.shared
+    let delegate = AppDelegate()
+    app.delegate = delegate
+    app.run()
+}


### PR DESCRIPTION
## Summary

- Add Swift Package (Swift 5.9, macOS 12+) with `itermfocus` executable target and embedded Info.plist via linker flags
- Implement CLI mode (`itermfocus <sessionId>`) that strips `w0t2p0:` prefix and runs AppleScript via osascript to find and focus the matching iTerm2 window/tab/pane
- Implement URL scheme mode (`itermfocus://session?sessionId=<UUID>`) via NSAppleEventManager handler with 1-second safety timeout for terminal-notifier integration
- Register `itermfocus://` URL scheme and set `LSBackgroundOnly` in Info.plist (no dock icon)